### PR TITLE
Fixed loading of images in github pages

### DIFF
--- a/index.html
+++ b/index.html
@@ -38,7 +38,7 @@
   <!-- About -->
   <section class="about row">
     <div class="col-6 left">
-      <img src="/assets/guitars.jpg" alt="Two red electric guitars over red background">
+      <img src="./assets/guitars.jpg" alt="Two red electric guitars over red background">
     </div>
     <div class="col-6 right">
       <h2 class="display-1">ABOUT</h2>
@@ -70,7 +70,7 @@
             <h3 class="title display-2">Hexagon</h3>
             <p class="price copy-lg">£25 vinyl</p>
           </div>
-          <img src="/assets/hexagon.jpg" alt="Hexagon vinyl by The Hexagons">
+          <img src="./assets/hexagon.jpg" alt="Hexagon vinyl by The Hexagons">
         </div>
         <!-- Album 2 - The Maze -->
         <div class="album">
@@ -78,7 +78,7 @@
             <h3 class="title display-2">The Maze</h3>
             <p class="price copy-lg">£25 vinyl</p>
           </div>
-          <img src="/assets/the-maze.jpg" alt="The Maze vinyl by The Hexagons">
+          <img src="./assets/the-maze.jpg" alt="The Maze vinyl by The Hexagons">
         </div>
         <!-- Album 3 - Happy -->
         <div class="album">
@@ -86,7 +86,7 @@
             <h3 class="title display-2">Happy</h3>
             <p class="price copy-lg">£5 single</p>
           </div>
-          <img src="/assets/happy.jpg" alt="Happy single by The Hexagons">
+          <img src="./assets/happy.jpg" alt="Happy single by The Hexagons">
         </div>
         <!-- Album 4 - Red and Blue -->
         <div class="album">
@@ -94,7 +94,7 @@
             <h3 class="title display-2">Red and Blue</h3>
             <p class="price copy-lg">£8 album</p>
           </div>
-          <img src="/assets/red-and-blue.jpg" alt="Red and Blue album by The Hexagons">
+          <img src="./assets/red-and-blue.jpg" alt="Red and Blue album by The Hexagons">
         </div>
         <!-- Album 5 - Shapeshifters -->
         <div class="album">
@@ -102,7 +102,7 @@
             <h3 class="title display-2">Shapeshifters</h3>
             <p class="price copy-lg">£12 album</p>
           </div>
-          <img src="/assets/shapeshifters.jpg" alt="Shapeshifters album by The Hexagons">
+          <img src="./assets/shapeshifters.jpg" alt="Shapeshifters album by The Hexagons">
         </div>
         <!-- Album 6 - Outburst -->
         <div class="album">
@@ -110,7 +110,7 @@
             <h3 class="title display-2">Outburst</h3>
             <p class="price copy-lg">£5 single</p>
           </div>
-          <img src="/assets/vi.jpg" alt="Outburst single by The Hexagons">
+          <img src="./assets/vi.jpg" alt="Outburst single by The Hexagons">
         </div>
       </div>
     </div>
@@ -118,7 +118,7 @@
 
   <!-- Footer -->
   <footer>
-    <img src="/assets/logo.svg" alt="The Hexagons">
+    <img src="./assets/logo.svg" alt="The Hexagons">
   </footer>
 
   <!-- Scripts -->

--- a/index.html
+++ b/index.html
@@ -24,7 +24,7 @@
             <a href="#">Music</a>
           </div>
           <div class="logo">
-            <img src="/assets/logo.svg" alt="The Hexagons">
+            <img src="./assets/logo.svg" alt="The Hexagons">
           </div>
           <div class="wrapper">
             <a href="#">Shows</a>


### PR DESCRIPTION
Earlier, the images weren't loading in github pages.

After adding "." before the src of img, for example
from src="/assets/logo.svg" 
to     src="./assets/logo.svg"

 it now loads perfectly.
